### PR TITLE
Fix chart not updating when operation date is moved back

### DIFF
--- a/lib/ui/screens/portfolio_screen.dart
+++ b/lib/ui/screens/portfolio_screen.dart
@@ -253,7 +253,7 @@ class _PortfolioScreenState extends State<PortfolioScreen> {
                       final allInvestments = context
                           .read<InvestmentProvider>()
                           .investments;
-                      chartProvider.loadHistory(allInvestments);
+                      await chartProvider.forceRebuildAndReload(allInvestments);
                       chartProvider.setVisibleSymbols(
                         allInvestments.map((e) => e.symbol).toSet(),
                       );


### PR DESCRIPTION
## Summary
- refresh chart history with forceRebuildAndReload when returning from asset detail screen after editing

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d7958934483268f73005ea5ca7d43